### PR TITLE
ci: add PublishNugetJob to GitHub Actions workflow

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -106,13 +106,15 @@ jobs:
     strategy:
       matrix:
         crate: [ "nuspec-test" ]
-        os: [ "ubuntu-latest", "windows-latest" ]
+        os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4.2.2 # immutable action, safe to use the versions
       - run: sudo apt install mono-devel
         if: ${{ matrix.os == 'ubuntu-latest' }}
+      - run: brew install mono
+        if: ${{ matrix.os == 'macos-latest' }}
       - uses: NuGet/setup-nuget@323ab0502cd38fdc493335025a96c8fdb0edc71f  # v2.0.1
       - run: cargo build --package ${{ matrix.crate }} --verbose --release
       - run: ls ./target/release

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -103,3 +103,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Publishing Passed"
+  PublishNugetJob:
+    strategy:
+      matrix:
+        crate: [ "nuspec-test" ]
+        os: [ "ubuntu-latest", "windows-latest" ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4.2.2 # immutable action, safe to use the versions
+      - uses: NuGet/setup-nuget@323ab0502cd38fdc493335025a96c8fdb0edc71f  # v2.0.1
+      - run: cargo build --package ${{ matrix.crate }} --verbose --release
+      - run: nuget pack ./target/release/${{ matrix.crate }}.nuspec
+  PublishNuget:
+    needs: PublishNugetJob
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Publishing Passed"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -103,6 +103,7 @@ jobs:
       matrix:
         crate: [ "nuspec-test" ]
         os: [ "ubuntu-latest", "windows-latest" ]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4.2.2 # immutable action, safe to use the versions
@@ -110,6 +111,8 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - uses: NuGet/setup-nuget@323ab0502cd38fdc493335025a96c8fdb0edc71f  # v2.0.1
       - run: cargo build --package ${{ matrix.crate }} --verbose --release
+      - run: ls ./target/release
+      - run: cat ./target/release/${{ matrix.crate }}.nuspec
       - run: nuget pack ./target/release/${{ matrix.crate }}.nuspec
   Publish:
     needs:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
   workflow_call:
     secrets:
       CODECOV_TOKEN:
@@ -90,14 +90,18 @@ jobs:
   PublishCrateJob:
     strategy:
       matrix:
-        crate: ["nuspec"]
+        crate: [ "nuspec" ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2 # immutable action, safe to use the versions
       - name: Dry run publish
-        run: |
-          cargo publish --all-features --package ${{ matrix.crate }} --dry-run --verbose
-          cargo package --all-features --list --allow-dirty
+        run: cargo publish --all-features --package ${{ matrix.crate }} --dry-run --verbose
+      - name: Create package
+        run: cargo package --all-features --package ${{ matrix.crate }} --verbose
+      - uses: actions/upload-artifact@v4.6.2 # immutable action, safe to use the versions
+        with:
+          name: ${{ matrix.crate }}-crate
+          path: target/package/${{ matrix.crate }}-*.crate
   PublishNugetJob:
     strategy:
       matrix:
@@ -114,10 +118,14 @@ jobs:
       - run: ls ./target/release
       - run: cat ./target/release/${{ matrix.crate }}.nuspec
       - run: nuget pack ./target/release/${{ matrix.crate }}.nuspec
+      - uses: actions/upload-artifact@v4.6.2 # immutable action, safe to use the versions
+        with:
+          name: ${{ matrix.crate }}-${{ matrix.os }}-nuget
+          path: ./${{ matrix.crate }}.*.nupkg
   Publish:
     needs:
-     - PublishNugetJob
-     - PublishCrateJob
+      - PublishNugetJob
+      - PublishCrateJob
     runs-on: ubuntu-latest
     steps:
       - run: echo "Publishing Passed"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -106,6 +106,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4.2.2 # immutable action, safe to use the versions
+      - run: sudo apt install mono-devel
+        if: ${{ matrix.os == 'ubuntu-latest' }}
       - uses: NuGet/setup-nuget@323ab0502cd38fdc493335025a96c8fdb0edc71f  # v2.0.1
       - run: cargo build --package ${{ matrix.crate }} --verbose --release
       - run: nuget pack ./target/release/${{ matrix.crate }}.nuspec

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -87,7 +87,7 @@ jobs:
         run: cargo machete
       - name: Deny
         run: cargo deny check all
-  PublishJob:
+  PublishCrateJob:
     strategy:
       matrix:
         crate: ["nuspec"]
@@ -98,11 +98,6 @@ jobs:
         run: |
           cargo publish --all-features --package ${{ matrix.crate }} --dry-run --verbose
           cargo package --all-features --list --allow-dirty
-  Publish:
-    needs: PublishJob
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Publishing Passed"
   PublishNugetJob:
     strategy:
       matrix:
@@ -114,8 +109,10 @@ jobs:
       - uses: NuGet/setup-nuget@323ab0502cd38fdc493335025a96c8fdb0edc71f  # v2.0.1
       - run: cargo build --package ${{ matrix.crate }} --verbose --release
       - run: nuget pack ./target/release/${{ matrix.crate }}.nuspec
-  PublishNuget:
-    needs: PublishNugetJob
+  Publish:
+    needs:
+     - PublishNugetJob
+     - PublishCrateJob
     runs-on: ubuntu-latest
     steps:
       - run: echo "Publishing Passed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ readme = "README.md"
 repository = "https://github.com/sv-tools/nuspec-rs"
 keywords = ["nuspec", "nuget", "nupkg"]
 categories = ["development-tools::build-utils"]
+version = "0.2.0"

--- a/crates/nuspec-test/Cargo.toml
+++ b/crates/nuspec-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nuspec-test"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/nuspec/Cargo.toml
+++ b/crates/nuspec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nuspec"
-version = "0.2.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Add a new job to the checks workflow that builds and packages the
nuspec-test crate for both Linux and Windows environments. This job
runs cargo build in release mode and creates a NuGet package using
nuget pack. The change ensures that the NuGet package is built and
tested across multiple OS platforms before publishing, improving
release reliability.