### PR TITLE
ci: update publish workflow to use crates-io-auth-action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2 # immutable action, safe to use the versions
+      - uses: rust-lang/crates-io-auth-action@e919bc7605cde86df457cf5b93c5e103838bd879 # v1.0.1
+        id: auth
       - name: Publish
-        run: |
-          cargo login ${{ secrets.CRATES_IO_TOKEN }}
-          cargo publish --all-features --package ${{ matrix.crate }} --verbose
+        run: cargo publish --all-features --package ${{ matrix.crate }} --verbose
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Replace manual cargo login with rust-lang/crates-io-auth-action to
handle authentication securely. This removes the need to expose the
CRATES_IO_TOKEN directly in the run command, improving security and
simplifying the publish step in the GitHub Actions workflow.