### PR TITLE
ci: add id-token write permission to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,6 +20,8 @@ jobs:
       matrix:
         crate: [ "nuspec" ]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4.2.2 # immutable action, safe to use the versions
       - uses: rust-lang/crates-io-auth-action@e919bc7605cde86df457cf5b93c5e103838bd879 # v1.0.1


### PR DESCRIPTION
Grant id-token write permission in the publish GitHub Actions workflow
to enable secure authentication for publishing the nuspec crate. This
change ensures the workflow has the necessary permissions to interact
with external services during the release process.